### PR TITLE
fix: avoid name clashing

### DIFF
--- a/src/hive/android/core.cljs
+++ b/src/hive/android/core.cljs
@@ -28,7 +28,7 @@
 (defn init []
   ;;------------- effect handlers --------------
   ; effects is a function of [values] -> void
-  (fx/register :fetch/json effects/fetch-json)
+  (fx/register :fetch/json effects/retrieve->json)
   (fx/register :app/exit   effects/quit)
   (fx/register :map/fly-to effects/center&zoom)
   ;; TODO: avoid having such long paremeters, prefer a simple default to simplify the function

--- a/src/hive/effects.cljs
+++ b/src/hive/effects.cljs
@@ -20,16 +20,19 @@
 (defn res->text [res] (.text res))
 (defn res->json [res] (.json res))
 
-(defn fetch
+(defn retrieve
+  "wrapper around React Native fetch function
+  See https://facebook.github.io/react-native/docs/network.html
+  for more information"
   [url opts on-response process-response]
   (-> (js/fetch url opts)
       (.then on-response)
       (.then process-response)
       (.catch #(println %))))
 
-(defn fetch-json
+(defn retrieve->json
   [[url options handler]]
-  (fetch url options res->json handler))
+  (retrieve url options res->json handler))
 
 (defn box-map
   "modify the mapview to display the area specified in the parameters"
@@ -55,4 +58,4 @@
   [v]
   (.exitApp fl/back-android))
 
-;(fetch "https://google.com" {} (cons res->json [#(println %)]))
+;(retrieve "https://google.com" {} (cons res->json [#(println %)]))


### PR DESCRIPTION
fix: rename fetch function to retrieve to avoid names collision with native javascript function