### PR TITLE
spec compliance. fixes #36

### DIFF
--- a/src/hive/android/core.cljs
+++ b/src/hive/android/core.cljs
@@ -35,21 +35,21 @@
   (fx/register :map/bound  effects/box-map)
   ;; ------------- event handlers -------------
   ;`db-handler` is a function: (db event) -> db
-  (rf/reg-event-db :hive/state events/init) ;;FIXME validate-spec
-  (rf/reg-event-db :map/ref events/assoc-rf)
-  (rf/reg-event-db :user/city (fn [db [id v]] (assoc db id v :map/camera [(:center v)])))
-  (rf/reg-event-db :user/location (fn [db [id gps]] (assoc db id (js->clj gps :keywordize-keys true))))
-  (rf/reg-event-db :view.home/targets events/assoc-rf)
-  (rf/reg-event-db :view/screen events/assoc-rf)
-  (rf/reg-event-db :view/side-menu events/assoc-rf)
+  (rf/reg-event-db :hive/state hijack/validate events/init)
+  (rf/reg-event-db :map/ref    hijack/validate events/assoc-rf)
+  (rf/reg-event-db :user/city  hijack/validate events/move-out)
+  (rf/reg-event-db :user/location     hijack/validate events/assoc-rf)
+  (rf/reg-event-db :view.home/targets hijack/validate events/assoc-rf)
+  (rf/reg-event-db :view/screen    hijack/validate events/assoc-rf)
+  (rf/reg-event-db :view/side-menu hijack/validate events/assoc-rf)
   ;; fx-handlers is a function [coeffects event] -> effects
-  (rf/reg-event-fx :user/goal events/destination)
+  (rf/reg-event-fx :user/goal events/destination);; json object not geojson conformen
   (rf/reg-event-fx :map/annotations events/targets)
   (rf/reg-event-fx :map/geocode [(before hijack/bypass-geocode) (before hijack/bias-geocode)]
                                 events/geocode)
-  (rf/reg-event-fx :map/directions [(before hijack/bypass-directions)] events/directions)
+  (rf/reg-event-fx :map/directions (before hijack/bypass-directions) events/directions)
   (rf/reg-event-fx :map/camera events/move-camera);; effect proxy to allow calling dispatch on it
-  (rf/reg-event-fx :view/return events/navigate-back)
+  (rf/reg-event-fx :view/return hijack/validate events/navigate-back)
   ;; ------------- queries ---------------------------------
   (subs/reg-sub :view.home/targets query/get-rf)
   (subs/reg-sub :view/side-menu query/get-rf)

--- a/src/hive/android/screens.cljs
+++ b/src/hive/android/screens.cljs
@@ -26,9 +26,9 @@
           (when @view-targets?
             [c/targets-list @map-markers])
           [c/mapview {:style                   {:flex 3} :initialZoomLevel hive.core/default-zoom :annotationsAreImmutable true
-                      :initialCenterCoordinate (util/feature->verbose @current-city) :annotations (clj->js @map-markers)
+                      :initialCenterCoordinate (util/feature->verbose @current-city) :annotations (clj->js (map util/feature->annotation @map-markers))
                       :showsUserLocation       true ;:ref (fn [this] (println "this: " this)) ;(when this (.keys this))))
-                      :onUpdateUserLocation    #(when % (router/dispatch [:user/location (util/verbose->feature %)]))
+                      :onUpdateUserLocation    #(when % (router/dispatch [:user/location (util/verbose->feature (js->clj % :keywordize-keys true))]))
                       :onTap                   #(router/dispatch [:view.home/targets false])
                       :ref                     (fn [mv] (router/dispatch [:map/ref mv]))}]]))))
 

--- a/src/hive/components.cljs
+++ b/src/hive/components.cljs
@@ -20,17 +20,16 @@
 (defn targets-list
   "list of items resulting from a geocode search, displayed to the user to choose his
   destination"
-  [targets]
-  [view {:style {:height (* 55 (count targets))}}
-   (for [t targets]
-     ^{:key (:id t)}
+  [features]
+  [view {:style {:height (* 55 (count features))}}
+   (for [target features]
+     ^{:key (:id target)}
      [touchable-highlight {:style    {:flex 1}
-                           :on-press (fn [] (router/dispatch [:map/directions
-                                                              (util/annotation->feature t)
+                           :on-press (fn [] (router/dispatch [:map/directions target
                                                               #(router/dispatch [:user/goal %])]))}
        [view {:style {:flex 1 :borderBottomColor "lightblue" :borderWidth 1}}
-         [text {:style {:flex 1}} (:title t)]
-         [text {:style {:flex 1 :color "gray"}} (:subtitle t)]]])])
+         [text {:style {:flex 1}} (:title target)]
+         [text {:style {:flex 1 :color "gray"}} (:subtitle target)]]])])
 
 (defn menu
   "side menu for the user to choose where to navigate to in Android"

--- a/src/hive/geojson.cljs
+++ b/src/hive/geojson.cljs
@@ -35,7 +35,7 @@
 (s/def :polygon/coordinates (s/coll-of :geojson/linear-ring))
 (s/def :multipolygon/coordinates (s/coll-of :polygon/coordinates))
 
-;FIXME
+;TODO
 ;FeatureCollection and Geometry objects, respectively, MUST
 ;NOT contain a "geometry" or "properties" member.
 (s/def :geocoll/geometries (s/coll-of :geojson/object))
@@ -86,6 +86,16 @@
 (s/def :geojson/feature-collection
   (s/keys :req-un [:featurecoll/type :featurecoll/features]
           :opt-un [:geojson/bbox]))
+
+
+;; -------------- utility functions
+
+(defn limited-feature
+  "returns an feature spec that conforms only to the specified geometry type
+  instead of any geometry object"
+  [geo-spec]
+  (s/keys :req-un [:feature/type (s/nilable geo-spec)]
+          :opt-un [:feature/id :geojson/bbox]))
 
 (defn failure?
   [object]

--- a/src/hive/interceptors.cljs
+++ b/src/hive/interceptors.cljs
@@ -23,12 +23,11 @@
   [spec db [event]]
   (when-not (s/valid? spec db)
     (let [explain-data (s/explain-data spec db)]
-      (throw (ex-info (str "Spec check after " event " failed: " explain-data) explain-data)))))
+      (throw (ex-info (str "INVALID STATE: " (s/explain-str spec db)) explain-data)))))
 
-(def validate-spec
-  (if goog.DEBUG
-    (nsa/after (partial check-and-throw :hive/state))
-    []))
+(def validate "interceptor to check valid db state"
+  (if-not goog.DEBUG []
+    (nsa/after (partial check-and-throw :hive/state))))
 
 (defn bypass-geocode
   "takes the parameters passed to create a MapBox geocode call and inserts the api


### PR DESCRIPTION
refactor: annotations as geojson objects
fix: annotation->feature missing extra values near the root
feature: geojson runtime spec creation for features